### PR TITLE
move tailwind style file to the env preview

### DIFF
--- a/components/envs/tailwind-bit/index.ts
+++ b/components/envs/tailwind-bit/index.ts
@@ -1,3 +1,3 @@
-import { TailwindReactExtension } from './tailwind-react.extension';
-export { TailwindReactExtension };
-export default TailwindReactExtension;
+export { TailwindReactAspect, TailwindReactAspect as default } from "./tailwind-react.aspect";
+export type { TailwindReactMain } from "./tailwind-react.main.runtime";
+export type { TailwindReactPreview } from "./tailwind-react.preview.runtime";

--- a/components/envs/tailwind-bit/tailwind-react.aspect.ts
+++ b/components/envs/tailwind-bit/tailwind-react.aspect.ts
@@ -1,0 +1,6 @@
+import { Aspect } from '@teambit/harmony';
+
+export const TailwindReactAspect = Aspect.create({
+  id: 'shohamgilad.tailwind-test/envs/tailwind-react',
+  defaultConfig: {},
+});

--- a/components/envs/tailwind-bit/tailwind-react.main.runtime.ts
+++ b/components/envs/tailwind-bit/tailwind-react.main.runtime.ts
@@ -1,10 +1,13 @@
+import { MainRuntime } from '@teambit/cli';
 import { EnvsMain, EnvsAspect } from '@teambit/envs'
 import { ReactAspect, ReactMain } from '@teambit/react'
+import { TailwindReactAspect } from './tailwind-react.aspect';
 import { previewConfig, devServerConfig } from './webpack';
 
-export class TailwindReactExtension {
+export class TailwindReactMain {
   constructor(private react: ReactMain) {}
 
+  static runtime = MainRuntime;
   static dependencies: any = [EnvsAspect, ReactAspect]
 
   static async provider([envs, react]: [EnvsMain, ReactMain]) {
@@ -20,6 +23,8 @@ export class TailwindReactExtension {
 
     envs.registerEnv(TailwindReactEnv)
 
-    return new TailwindReactExtension(react)
+    return new TailwindReactMain(react)
   }
 }
+
+TailwindReactAspect.addRuntime(TailwindReactMain);

--- a/components/envs/tailwind-bit/tailwind-react.preview.runtime.tsx
+++ b/components/envs/tailwind-bit/tailwind-react.preview.runtime.tsx
@@ -1,0 +1,23 @@
+import { PreviewRuntime } from '@teambit/preview';
+import { ReactAspect, ReactPreview } from '@teambit/react';
+
+import { TailwindReactAspect } from './tailwind-react.aspect';
+
+// load tailwind global custom styles, for compositions
+import '@shohamgilad/tailwind-test.styles.tailwind-styles/dist/styles.css';
+
+export class TailwindReactPreview {
+  static runtime = PreviewRuntime;
+  static dependencies = [ReactAspect];
+
+  static async provider([react]: [ReactPreview]) {
+    const reactEnvPreview = new TailwindReactPreview();
+
+    const previewDecorators = [/* add preview providers here */];
+    react.registerProvider(previewDecorators);
+
+    return reactEnvPreview;
+  }
+}
+
+TailwindReactAspect.addRuntime(TailwindReactPreview);

--- a/components/ui/button/components/tailwind-button/tailwind-button.tsx
+++ b/components/ui/button/components/tailwind-button/tailwind-button.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import '@shohamgilad/tailwind-test.styles.tailwind-styles/dist/styles.css';
 
 export type TailwindButtonProps = {
   /**

--- a/components/ui/themed-component/themed-component.tsx
+++ b/components/ui/themed-component/themed-component.tsx
@@ -1,5 +1,4 @@
 import React, { ReactElement } from "react";
-import "@shohamgilad/tailwind-test.styles.tailwind-styles/dist/styles.css";
 
 export type ThemedComponentProps = {
   className: string;


### PR DESCRIPTION
- split tailwind env from `.extension` file to `main.runtime` and `preview.runtime`.
- move all tailwind global css style file to the env preview.